### PR TITLE
Fix adding consumer key to request builder

### DIFF
--- a/usos-core/src/api/auth.rs
+++ b/usos-core/src/api/auth.rs
@@ -37,7 +37,7 @@ pub async fn acquire_request_token(
     let body = CLIENT
         .builder("oauth/request_token")
         .payload([("oauth_callback", callback), ("scopes", scopes.to_string())])
-        .auth(Some(consumer_key), None)
+        .auth(Some(&*consumer_key), None)
         .request()
         .await?
         .text()
@@ -71,7 +71,7 @@ pub async fn acquire_access_token(
         .builder("oauth/access_token")
         .payload([("oauth_verifier", verifier.into())])
         .auth(
-            Some(consumer_key),
+            Some(&*consumer_key),
             Some(&AccessToken {
                 token: request_token.token,
                 secret: request_token.secret,


### PR DESCRIPTION
- Consumer key can be added in a request builder when no default consumer key is set
- Inside a request builder, a reference to the consumer key is stored instead of Arc
- Consumer key and access token are stored independently of each other, and access token is still sent in a request only when consumer key is set.